### PR TITLE
🐛fix : 게시글 상세 조회 시 file, category, area, interest 객체로 반환

### DIFF
--- a/apps/posts/serializers.py
+++ b/apps/posts/serializers.py
@@ -1,19 +1,105 @@
 from rest_framework import serializers
 
+from apps.options.models.area import Area
+from apps.options.models.category import Category
+from apps.options.models.interest import Interest
+from apps.upload.models import File
+
 from .models import Comment, Like, Post, PostImage
 
 
+# 1. 옵션 필드용 Serializer
+class CategoryNameSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="category_name", read_only=True)
+
+    class Meta:
+        model = Category
+        fields = ["id", "name"]
+
+
+class AreaNameSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="area_name", read_only=True)
+
+    class Meta:
+        model = Area
+        fields = ["id", "name"]
+
+
+class InterestNameSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="interest_name", read_only=True)
+
+    class Meta:
+        model = Interest
+        fields = ["id", "name"]
+
+
+# 2. 파일 상세용 Serializer (필요한 필드만 포함, 썸네일은 url로 반환)
+class FileSerializer(serializers.ModelSerializer):
+    file = serializers.FileField()
+    thumbnail = serializers.ImageField()
+    user_id = serializers.PrimaryKeyRelatedField(source="user", read_only=True)
+
+    class Meta:
+        model = File
+        fields = [
+            "id",
+            "user_id",
+            "file",
+            "file_type",
+            "file_name",
+            "file_size",
+            "thumbnail",
+            "uploaded_at",
+        ]
+
+
+# 3. PostImage는 필요하면 그대로 사용
 class PostImageSerializer(serializers.ModelSerializer):
     class Meta:
         model = PostImage
         fields = ["id", "file"]
 
 
+# 4. PostSerializer
 class PostSerializer(serializers.ModelSerializer):
+    # 읽기용(응답) 직렬화
+    category = CategoryNameSerializer(read_only=True)
+    area = AreaNameSerializer(read_only=True)
+    interest = InterestNameSerializer(read_only=True)
+    file = FileSerializer(read_only=True)
+
+    # 쓰기용(등록/수정) 필드
+    category_id = serializers.PrimaryKeyRelatedField(
+        queryset=Category.objects.all(),
+        source="category",
+        write_only=True,
+        required=True,
+    )
+    area_id = serializers.PrimaryKeyRelatedField(
+        queryset=Area.objects.all(),
+        source="area",
+        write_only=True,
+        required=False,
+        allow_null=True,
+    )
+    interest_id = serializers.PrimaryKeyRelatedField(
+        queryset=Interest.objects.all(),
+        source="interest",
+        write_only=True,
+        required=False,
+        allow_null=True,
+    )
+    file_id = serializers.PrimaryKeyRelatedField(
+        queryset=File.objects.all(),
+        source="file",
+        write_only=True,
+        required=False,
+        allow_null=True,
+    )
+
     nickname = serializers.CharField(source="user.nickname", read_only=True)
     like_count = serializers.IntegerField(source="likes.count", read_only=True)
-    # is_liked = serializers.SerializerMethodField()
-    is_mine = serializers.BooleanField(read_only=True)
+    is_mine = serializers.SerializerMethodField()
 
     class Meta:
         model = Post
@@ -21,41 +107,56 @@ class PostSerializer(serializers.ModelSerializer):
             "id",
             "title",
             "content",
-            "category",
+            "category",  # 읽기
+            "category_id",  # 쓰기
             "area",
+            "area_id",
             "interest",
+            "interest_id",
             "file",
+            "file_id",
             "created_at",
             "updated_at",
             "nickname",
             "is_mine",
             "like_count",
-            #    "is_liked",
         ]
 
     def get_is_mine(self, obj):
         request = self.context.get("request")
         return request and request.user.is_authenticated and obj.user == request.user
 
-    # def get_is_liked(self, obj):
-    #    request = self.context.get("request")
-    #    if not request or not request.user.is_authenticated:
-    #        return False
-    #    return obj.likes.filter(user=request.user).exists()
+    # Create, update 시에는 id값만 받도록 override
+    def to_internal_value(self, data):
+        ret = super().to_internal_value(data)
+        # POST/PUT/PATCH에서 category/area/interest/file의 id를 매핑
+        for field, model in [
+            ("category", Category),
+            ("area", Area),
+            ("interest", Interest),
+            ("file", File),
+        ]:
+            val = data.get(field)
+            if val:
+                try:
+                    ret[field] = model.objects.get(pk=val)
+                except model.DoesNotExist:
+                    self.fail(f"{field}_not_found")
+        return ret
 
 
+# 5. RecursiveField (대댓글 용)
 class RecursiveField(serializers.Serializer):
-    """대댓글 구조(트리) 직렬화용"""
-
     def to_representation(self, value):
         serializer = self.parent.parent.__class__(value, context=self.context)
         return serializer.data
 
 
+# 6. CommentSerializer
 class CommentSerializer(serializers.ModelSerializer):
     nickname = serializers.CharField(source="user.nickname", read_only=True)
     is_mine = serializers.SerializerMethodField()
-    replies = RecursiveField(many=True, read_only=True)  # 대댓글들
+    replies = RecursiveField(many=True, read_only=True)
 
     class Meta:
         model = Comment
@@ -86,12 +187,12 @@ class CommentSerializer(serializers.ModelSerializer):
         return request and request.user.is_authenticated and obj.user == request.user
 
     def create(self, validated_data):
-        # user, post는 validated_data에서 빼고, 따로 set
         user = validated_data.pop("user")
         post = validated_data.pop("post")
         return Comment.objects.create(user=user, post=post, **validated_data)
 
 
+# 7. LikeSerializer
 class LikeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Like

--- a/apps/posts/views.py
+++ b/apps/posts/views.py
@@ -1,5 +1,5 @@
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import filters, generics, permissions, status
+from rest_framework import filters, generics, permissions
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -16,6 +16,13 @@ class PostListCreateView(generics.ListCreateAPIView):
     search_fields = ["title", "content"]
 
     @swagger_auto_schema(tags=["게시글"])
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    @swagger_auto_schema(tags=["게시글"])
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
@@ -25,6 +32,18 @@ class PostDetailView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = PostSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
+    @swagger_auto_schema(tags=["게시글"])
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    @swagger_auto_schema(tags=["게시글"])
+    def patch(self, request, *args, **kwargs):
+        return super().patch(request, *args, **kwargs)
+
+    @swagger_auto_schema(tags=["게시글"])
+    def delete(self, request, *args, **kwargs):
+        return super().delete(request, *args, **kwargs)
+
     def perform_update(self, serializer):
         # 본인만 수정/삭제 가능 로직 필요
         if self.request.user != self.get_object().user:
@@ -33,14 +52,17 @@ class PostDetailView(generics.RetrieveUpdateDestroyAPIView):
 
 
 class CommentListCreateView(generics.ListCreateAPIView):
-
-    queryset = Comment.objects.filter(parent=None).order_by(
-        "-created_at"
-    )  # 최상위 댓글만
     serializer_class = CommentSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     @swagger_auto_schema(tags=["댓글"])
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    @swagger_auto_schema(tags=["댓글"])
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
     def get_queryset(self):
         # 특정 게시글(post_id)에 대한 댓글만
         post_id = self.kwargs["post_id"]
@@ -58,6 +80,18 @@ class CommentDetailView(generics.RetrieveUpdateDestroyAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+    @swagger_auto_schema(tags=["댓글"])
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    @swagger_auto_schema(tags=["댓글"])
+    def patch(self, request, *args, **kwargs):
+        return super().patch(request, *args, **kwargs)
+
+    @swagger_auto_schema(tags=["댓글"])
+    def delete(self, request, *args, **kwargs):
+        return super().delete(request, *args, **kwargs)
 
     def perform_update(self, serializer):
         if self.request.user != self.get_object().user:


### PR DESCRIPTION
## 📝작업 내용

- file, category, area, interest를 id만 아닌 객체 형태({id, name...})로 응답
- file 필드는 FileSerializer 활용해서 상세 정보 반환
- 프론트 매핑 없이 바로 렌더링 가능하도록 개선